### PR TITLE
[backend/S3, Food] 음식기능 수정과 S3 파일 업로드 유틸 구현

### DIFF
--- a/backend/server/build.gradle
+++ b/backend/server/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'org.json:json:20211205' //JSON Parser
     implementation 'org.springframework.boot:spring-boot-starter-security' // 스프링 시큐리티
     implementation 'io.jsonwebtoken:jjwt:0.9.1' // jwt
-
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // s3
 }
 
 tasks.named('test') {

--- a/backend/server/src/main/java/capstone/server/config/S3Config.java
+++ b/backend/server/src/main/java/capstone/server/config/S3Config.java
@@ -5,6 +5,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -17,7 +18,7 @@ public class S3Config {
 
     @Value("${cloud.aws.region.static}")
     private String region;
-
+    @Bean
     public AmazonS3 amazonS3Client() {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         return AmazonS3ClientBuilder.standard()

--- a/backend/server/src/main/java/capstone/server/config/S3Config.java
+++ b/backend/server/src/main/java/capstone/server/config/S3Config.java
@@ -1,0 +1,28 @@
+package capstone.server.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/backend/server/src/main/java/capstone/server/domain/food/controller/FoodController.java
+++ b/backend/server/src/main/java/capstone/server/domain/food/controller/FoodController.java
@@ -11,12 +11,14 @@ import capstone.server.utils.KaKaoUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -28,24 +30,28 @@ public class FoodController {
     private FoodService foodService;
 
     @PostMapping(value = "/food/detect")
-    public ResponseEntity<?> detectFoodImage(Authentication authentication, @RequestPart(value = "image")MultipartFile image) {
+    public ResponseEntity<?> detectFoodImage(Authentication authentication, @RequestParam(value = "image")MultipartFile image) {
 
         try {
             FoodDetectionResponseDto result = foodService.detectFoodImage(image);
             return ResponseEntity.ok().body(result);
         } catch (HttpClientErrorException e) {
             return ResponseEntity.status(e.getStatusCode()).body(e.getResponseBodyAsString());
+        } catch (IOException e) {
+            return ResponseEntity.ok().body(e.getMessage());
         }
     }
 
     @PostMapping(value = "/food/")
-    public ResponseEntity<?> registerFood(Authentication authentication, @RequestBody RegisterFoodDto foods) {
+    public ResponseEntity<?> registerFood(Authentication authentication, @RequestPart(value = "image") MultipartFile image, @RequestPart(value = "food_info") RegisterFoodDto foods) {
         try {
             KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType = KaKaoUtil.authConvertIdAndTypeDto(authentication);
-            ResponseEntity result = foodService.registerFood(kaKaoAccountIdAndUserType.getKakaoAccountId(), foods);
+            ResponseEntity result = foodService.registerFood(kaKaoAccountIdAndUserType, image, foods);
             return result;
         } catch (HttpClientErrorException e) {
             return ResponseEntity.status(e.getStatusCode()).body(e.getResponseBodyAsString());
+        } catch (IOException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 

--- a/backend/server/src/main/java/capstone/server/domain/food/controller/FoodController.java
+++ b/backend/server/src/main/java/capstone/server/domain/food/controller/FoodController.java
@@ -68,5 +68,16 @@ public class FoodController {
         }
     }
 
+    @DeleteMapping(value = "/food/{id}")
+    public ResponseEntity<?> deleteMeal(Authentication authentication, @PathVariable Long id) {
+        try {
+            KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType = KaKaoUtil.authConvertIdAndTypeDto(authentication);
+            ResponseEntity result = foodService.deleteMeal(id);
+            return result;
+        } catch (HttpClientErrorException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(e.getResponseBodyAsString());
+        }
+    }
+
 
 }

--- a/backend/server/src/main/java/capstone/server/domain/food/dto/MealInfo.java
+++ b/backend/server/src/main/java/capstone/server/domain/food/dto/MealInfo.java
@@ -16,5 +16,6 @@ public class MealInfo {
     private Long id;
     private LocalDateTime dateTime;
     private int times;
+    private String imageUrl;
     private List<FoodInfo> detail;
 }

--- a/backend/server/src/main/java/capstone/server/domain/food/service/FoodService.java
+++ b/backend/server/src/main/java/capstone/server/domain/food/service/FoodService.java
@@ -18,4 +18,6 @@ public interface FoodService {
 
     public GetFoodInfoResponseDto getFoodInfo(KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType);
 
+    public ResponseEntity deleteMeal(Long mealId);
+
 }

--- a/backend/server/src/main/java/capstone/server/domain/food/service/FoodService.java
+++ b/backend/server/src/main/java/capstone/server/domain/food/service/FoodService.java
@@ -8,11 +8,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @Service
 public interface FoodService {
 
-    public FoodDetectionResponseDto detectFoodImage(MultipartFile image);
-    public ResponseEntity registerFood(Long kakaoAccountId, RegisterFoodDto registerFoodDto);
+    public FoodDetectionResponseDto detectFoodImage(MultipartFile image) throws IOException;
+    public ResponseEntity registerFood(KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType, MultipartFile image, RegisterFoodDto registerFoodDto) throws IOException;
 
     public GetFoodInfoResponseDto getFoodInfo(KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType);
 

--- a/backend/server/src/main/java/capstone/server/domain/food/service/FoodServiceImpl.java
+++ b/backend/server/src/main/java/capstone/server/domain/food/service/FoodServiceImpl.java
@@ -166,4 +166,10 @@ public class FoodServiceImpl implements FoodService{
 
         return getFoodInfoResponseDto;
     }
+
+    @Override
+    public ResponseEntity deleteMeal(Long mealId) {
+        mealRepository.deleteById(mealId);
+        return ResponseEntity.ok().body("success");
+    }
 }

--- a/backend/server/src/main/java/capstone/server/domain/food/service/FoodServiceImpl.java
+++ b/backend/server/src/main/java/capstone/server/domain/food/service/FoodServiceImpl.java
@@ -161,6 +161,7 @@ public class FoodServiceImpl implements FoodService{
                     .id(meal.getId())
                     .dateTime(meal.getCreatedAt())
                     .times(meal.getTimes())
+                    .imageUrl(meal.getImage().getUrl())
                     .detail(details).build());
         }
 

--- a/backend/server/src/main/java/capstone/server/domain/image/repository/ImageRepository.java
+++ b/backend/server/src/main/java/capstone/server/domain/image/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package capstone.server.domain.image.repository;
+
+import capstone.server.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/backend/server/src/main/java/capstone/server/entity/Image.java
+++ b/backend/server/src/main/java/capstone/server/entity/Image.java
@@ -1,0 +1,25 @@
+package capstone.server.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@ToString
+@Table(name = "image")
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "tile")
+    private String title;
+
+    @Column(name = "url")
+    private String url;
+}

--- a/backend/server/src/main/java/capstone/server/entity/Image.java
+++ b/backend/server/src/main/java/capstone/server/entity/Image.java
@@ -1,5 +1,6 @@
 package capstone.server.entity;
 
+import capstone.server.utils.BaseTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Image {
+public class Image extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")

--- a/backend/server/src/main/java/capstone/server/entity/Meal.java
+++ b/backend/server/src/main/java/capstone/server/entity/Meal.java
@@ -6,6 +6,7 @@ import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter @ToString
 @Table(name = "meal")
@@ -29,5 +30,9 @@ public class Meal extends BaseTimeEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_ward_user_id")
   private UserWard userWard;
+
+  @OneToMany(mappedBy = "meal", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Food> foods;
+
 
 }

--- a/backend/server/src/main/java/capstone/server/entity/Meal.java
+++ b/backend/server/src/main/java/capstone/server/entity/Meal.java
@@ -22,6 +22,10 @@ public class Meal extends BaseTimeEntity {
   @Column(name = "times")
   private int times;  // 몇끼째인지 확인하기 위한 용도
 
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "image_id")
+  private Image image;
+
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_ward_user_id")
   private UserWard userWard;

--- a/backend/server/src/main/java/capstone/server/utils/S3Util.java
+++ b/backend/server/src/main/java/capstone/server/utils/S3Util.java
@@ -1,0 +1,33 @@
+package capstone.server.utils;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Util {
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3Client amazonS3Client;
+    public String uploadFile(MultipartFile file) throws IOException {
+        String fileName = file.getOriginalFilename();
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getInputStream().available());
+        amazonS3Client.putObject(bucket, fileName, file.getInputStream(), objectMetadata);
+
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+}

--- a/backend/server/src/main/java/capstone/server/utils/S3Util.java
+++ b/backend/server/src/main/java/capstone/server/utils/S3Util.java
@@ -22,10 +22,10 @@ public class S3Util {
     private String bucket;
 
     private final AmazonS3Client amazonS3Client;
-    public String uploadFile(MultipartFile file) throws IOException {
-        String fileName = file.getOriginalFilename();
+    public String uploadFile(MultipartFile file, String fileName) throws IOException {
         ObjectMetadata objectMetadata = new ObjectMetadata();
         objectMetadata.setContentLength(file.getInputStream().available());
+        // S3에 파일 업로드
         amazonS3Client.putObject(bucket, fileName, file.getInputStream(), objectMetadata);
 
         return amazonS3Client.getUrl(bucket, fileName).toString();


### PR DESCRIPTION
## 🚩 관련 이슈
- close #67 
- close #69 

하다보니까 이슈나누어 놓은지 모르고 두개모두 구현함


## 📋 구현 기능 명세
- [x] 스프링부트에 S3연결
- [x] 이미지 엔티티 만들어서 s3에 올린 이미지는 db에 저장. 
- [x] 사진 S3에 올리고 DB에 저장하고 URL 불러오는 기능 구현
- [x] 음식 조회할때도 이미지 URL 첨부하게 만듬  
- [x] 식사 삭제기능 구현(음식 데이터들도 함께 삭제됨) 



## 🚀 API Endpoint
- /api/food/detect
- /api/food
