### PR TITLE
[fix] gradle.yml 스크립트에서 resources 폴더 생성 코드 삭제

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
     # application.properties 생성 
     - name: make application.properties
       run:
-        mkdir ./src/main/resources | 
+        # mkdir ./src/main/resources | 
         touch ./src/main/resources/application.properties 
       shell: bash
       working-directory: backend/server


### PR DESCRIPTION
- 정적파일로 인해서 이미 파일들 차있음

## 🚩 관련 이슈
- close #118 

## 📋 구현 기능 명세
- [x] 이메일 템플릿으로 메일전송
- [x] 음식 등록시 메일 전송
- [x] 배포 gradle.yml 커맨드에서 mkdir 부분 삭제 -> resources파일들이 존재해버리기떄문에
- [ ] 

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /
