### PR TITLE
[Backend/Calender] 보호자 뷰에서 캘린더 데이터 API 추가

### DIFF
--- a/backend/server/src/main/java/capstone/server/domain/user/controller/UserGuardianController.java
+++ b/backend/server/src/main/java/capstone/server/domain/user/controller/UserGuardianController.java
@@ -1,5 +1,6 @@
 package capstone.server.domain.user.controller;
 
+import capstone.server.domain.calendar.dto.GetRecordsDateResponseDto;
 import capstone.server.domain.food.dto.GetFoodInfoResponseDto;
 import capstone.server.domain.food.service.FoodService;
 import capstone.server.domain.login.dto.KaKaoAccountIdAndUserType;
@@ -283,6 +284,23 @@ public class UserGuardianController {
                             .status(HttpStatus.BAD_REQUEST.value())
                             .message("등록되어있지 않은 유저이거나 이미 삭제되었습니다.")
                             .success(false)
+                            .build()
+            );
+        }
+    }
+
+    @GetMapping(value = "/calendar")
+    public ResponseEntity<?> getRecordsDate(Authentication authentication, @PathVariable Long userWardId) {
+        try {
+            GetRecordsDateResponseDto result = userGuardianService.getRecordsDate(userWardId);
+
+            return ResponseEntity.ok().body(result);
+        } catch (HttpClientErrorException e) {
+            return ResponseEntity.status(e.getStatusCode()).body(
+                    DefaultResponse.builder()
+                            .success(false)
+                            .status(e.getStatusCode().value())
+                            .message(e.getResponseBodyAsString())
                             .build()
             );
         }

--- a/backend/server/src/main/java/capstone/server/domain/user/service/UserGuardianService.java
+++ b/backend/server/src/main/java/capstone/server/domain/user/service/UserGuardianService.java
@@ -1,5 +1,6 @@
 package capstone.server.domain.user.service;
 
+import capstone.server.domain.calendar.dto.GetRecordsDateResponseDto;
 import capstone.server.domain.food.dto.GetFoodInfoResponseDto;
 import capstone.server.domain.login.dto.KaKaoAccountIdAndUserType;
 import capstone.server.domain.medicine.dto.GetMedicineInfoResponseDto;
@@ -25,4 +26,5 @@ public interface UserGuardianService {
     public GetMedicineInfoResponseDto getMedicineInfo(Long userWardKakaoAccountId);
     public String connectWard(KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType, Long userWardKakaoAccountId);
     public String disconnectWard(KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType, Long userWardKakaoAccountId);
+    public GetRecordsDateResponseDto getRecordsDate(Long userWardKakaoAccountId);
 }

--- a/backend/server/src/main/java/capstone/server/domain/user/service/UserGuardianServiceImpl.java
+++ b/backend/server/src/main/java/capstone/server/domain/user/service/UserGuardianServiceImpl.java
@@ -1,5 +1,7 @@
 package capstone.server.domain.user.service;
 
+import capstone.server.domain.calendar.dto.GetRecordsDateResponseDto;
+import capstone.server.domain.calendar.service.CalendarService;
 import capstone.server.domain.food.dto.GetFoodInfoResponseDto;
 import capstone.server.domain.food.service.FoodService;
 import capstone.server.domain.login.dto.KaKaoAccountIdAndUserType;
@@ -43,6 +45,7 @@ public class UserGuardianServiceImpl implements UserGuardianService {
     private final UserGuardianRepository userGuardianRepository;
     private final UserWardRepository userWardRepository;
     private final UserGuardianUserWardRepository userGuardianUserWardRepository;
+    private final CalendarService calendarService;
 
     @Override
     public GetUserWardMainInfoResponseDto getUserWardMainInfo(Long userWardKakaoAccountId) throws HttpClientErrorException {
@@ -188,5 +191,15 @@ public class UserGuardianServiceImpl implements UserGuardianService {
         userGuardianUserWardRepository.deleteByUserGuardianAndUserWard(userGuardian, userWard);
 
         return "해당 연결이 정상적으로 삭제되었습니다.";
+    }
+
+    @Override
+    public GetRecordsDateResponseDto getRecordsDate(Long userWardKakaoAccountId) {
+        KaKaoAccountIdAndUserType kaKaoAccountIdAndUserType = KaKaoAccountIdAndUserType.builder()
+                .userType("ward")
+                .kakaoAccountId(userWardKakaoAccountId)
+                .build();
+
+        return calendarService.getRecordsDate(kaKaoAccountIdAndUserType);
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #201 

## 📋 구현 기능 명세
- [x] 보호자 뷰에서 캘린더 데이터 API 추가

## 🚀 API Endpoint
- /userguardian/calendar
